### PR TITLE
Deleted description of report sections

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -30,13 +30,3 @@ This tool has been created as part of the REEEM project to provide insights into
 />
 
 This tool aims to synthesise the work carried out in REEEM, to extract the main messages from the project activities and to point out the main impacts. It revolves around the main objective of the project, which is to provide a comprehensive understanding of the system-wide implications of energy strategies in support of transitions to a competitive low-carbon EU energy society. This tool constitutes an online version of the Final Integrated Impact Report. It embeds methodological discussions extensively taken under deliverable D1.1 - Report on pathway definition, and it summarises the findings of the studies presented in all other project deliverables (Case study reports, Focus reports and sectoral Policy Briefs).
-
-Section 1 sets the background: it focuses on the EU’s strategic priorities for the energy system, identifies the challenges related to such priorities and summarises the contributions of key EU-funded actions to addressing such challenges. The mentioned funded actions represent past or present efforts which the project partners have collaborated with. Aim of the REEEM Consortium in this respect has been to leverage on experience from previous actions and complement the findings of current actions.
-
-Section 2 describes the design of the REEEM Pathways: a set of scenarios specifically designed, with stakeholders, to look into the above challenges and provide insights complementing those of other efforts.
-
-Section 3 provides a large set of messages obtained through an integrated modelling framework, casting light on the challenges and opportunities of decarbonisation in various subsectors of the economy, society and environment.
-
-Section 4 extracts recommendations from the sectoral messages listed before.
-
-Section 5 provides a case on how the messages and recommendations presented in the previous sections may be transferred to various stakeholders of the transition.


### PR DESCRIPTION
Since the report sections are not really relevant (from my perspective) in the pathways tool I removed them to not confuse the users.